### PR TITLE
Use hash based router and remove /zipkin base path.

### DIFF
--- a/src/components/App/Header/TraceId.js
+++ b/src/components/App/Header/TraceId.js
@@ -44,7 +44,7 @@ class TraceId extends React.Component {
     const { history } = this.props;
     const { traceId } = this.state;
     if (e.key === 'Enter') {
-      history.push(`/zipkin/trace/${traceId}`);
+      history.push(`/trace/${traceId}`);
     }
   }
 

--- a/src/components/App/Header/index.js
+++ b/src/components/App/Header/index.js
@@ -25,8 +25,8 @@ const propTypes = {
 };
 
 const Header = ({ location }) => {
-  const isBrowserSelected = location.pathname === '/zipkin';
-  const isDependenciesSelected = location.pathname === '/zipkin/dependencies';
+  const isBrowserSelected = location.pathname === '/';
+  const isDependenciesSelected = location.pathname === '/dependencies';
 
   return (
     <header className="header">
@@ -41,7 +41,7 @@ const Header = ({ location }) => {
         <div className="header__menu">
           <div className={`header__option ${isBrowserSelected ? 'selected' : ''}`}>
             <Link
-              to={{ pathname: '/zipkin' }}
+              to={{ pathname: '/' }}
               className={`header__option-link ${isBrowserSelected ? 'selected' : ''}`}
             >
               <i className="fas fa-search header__option-icon" />
@@ -50,7 +50,7 @@ const Header = ({ location }) => {
           </div>
           <div className={`header__option ${isDependenciesSelected ? 'selected' : ''}`}>
             <Link
-              to={{ pathname: '/zipkin/dependencies' }}
+              to={{ pathname: '/dependencies' }}
               className={`header__option-link ${isDependenciesSelected ? 'selected' : ''}`}
             >
               <i className="fas fa-code-branch header__option-icon" />

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { HashRouter as Router, Route } from 'react-router-dom';
 
 import Layout from './Layout';
 import BrowserContainer from '../../containers/Browser/BrowserContainer';
@@ -26,11 +26,11 @@ import configureStore from '../../store/configure-store';
 
 const App = () => (
   <Provider store={configureStore()}>
-    <BrowserRouter>
+    <Router>
       <div>
         <Route
           exact
-          path="/zipkin"
+          path={["", "/"]}
           render={props => (
             <Layout {...props}>
               <BrowserContainer {...props} />
@@ -39,7 +39,7 @@ const App = () => (
         />
         <Route
           exact
-          path="/zipkin/trace/:traceId"
+          path="/trace/:traceId"
           render={props => (
             <Layout {...props}>
               <TraceContainer {...props} />
@@ -48,7 +48,7 @@ const App = () => (
         />
         <Route
           exact
-          path="/zipkin/dependencies"
+          path="/dependencies"
           render={props => (
             <Layout {...props}>
               <DependenciesContainer {...props} />
@@ -56,7 +56,7 @@ const App = () => (
           )}
         />
       </div>
-    </BrowserRouter>
+    </Router>
   </Provider>
 );
 

--- a/src/components/Browser/Traces/Trace.js
+++ b/src/components/Browser/Traces/Trace.js
@@ -154,7 +154,7 @@ class Trace extends React.Component {
           </div>
           <div className="traces__trace-link-wrapper">
             <Link
-              to={{ pathname: `/zipkin/trace/${traceSummary.traceId}` }}
+              to={{ pathname: `/trace/${traceSummary.traceId}` }}
             >
               <Button className="traces__trace-link">
                 <i className="fas fa-door-open" />

--- a/src/components/Dependencies/index.js
+++ b/src/components/Dependencies/index.js
@@ -160,7 +160,7 @@ class Dependencies extends React.Component {
                 </div>
                 <div className="dependencies__search-button-wrapper">
                   <Link to={{
-                    pathname: '/zipkin/dependencies',
+                    pathname: '/dependencies',
                     search: buildQueryParameters({
                       endTs: endTs.valueOf(),
                       lookback: endTs.valueOf() - startTs.valueOf(),

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -11,7 +11,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, './dist'),
     filename: 'bundle.js',
-    publicPath: '/zipkin/',
+    publicPath: '',
   },
   module: {
     rules: [


### PR DESCRIPTION
Using hash based paths should make things cleaner when embedding the single page application in static resource servers like Spring Boot.  In addition we can also remove the /zipkin base path and delegate base path configuration to the resource server.