### PR TITLE
Redirect the home page to /zipkin temporarily

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter, Route, Redirect } from 'react-router-dom';
 
 import Layout from './Layout';
 import BrowserContainer from '../../containers/Browser/BrowserContainer';
@@ -28,6 +28,13 @@ const App = () => (
   <Provider store={configureStore()}>
     <BrowserRouter>
       <div>
+        <Route
+          exact
+          path="/"
+          render={() => (
+            <Redirect to="/zipkin" />
+          )}
+        />
         <Route
           exact
           path="/zipkin"


### PR DESCRIPTION
When I started zipkin-lens in my local env and opened http://localhost:9000, it didn’t show anything.

After I looked at the source code, I found that I have to visit `/zipkin` to see the traces. I think because of webpack's publicPath it is normal in production env, would it be more user-friendly to redirect the home page to `/zipkin` temporarily for users who use `npm run start`? 
